### PR TITLE
fix: bug get evaluations without

### DIFF
--- a/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
+++ b/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
@@ -143,8 +143,7 @@ public class EmployeeEvaluationServiceImpl implements EmployeeEvaluationService 
                 .middleScore(responseRatingDto == null ? 0 : responseRatingDto.getRating())
                 .evaluations(filterEvaluations(adminEvaluations, usersEvaluations, questionnaire.getCriterias()))
                 .recommendation(recommendation == null
-                        ? "Рекомендация не оставлена"
-                        : recommendation.getRecommendation())
+                        ? "" : recommendation.getRecommendation())
                 .build();
     }
 
@@ -172,8 +171,7 @@ public class EmployeeEvaluationServiceImpl implements EmployeeEvaluationService 
                         ? 0 : responseRatingDto.getRating())
                 .evaluations(filterEvaluations(adminEvaluations, usersEvaluations, questionnaire.getCriterias()))
                 .recommendation(recommendation == null
-                        ? "Рекомендация не оставлена"
-                        : recommendation.getRecommendation())
+                        ? "" : recommendation.getRecommendation())
                 .build();
     }
 


### PR DESCRIPTION
Исправлена ошибка 403, возникала при запросе оценок в случае когда оценки поставил только руководитель.