### PR TITLE
fix(evaluations): make long 409 CONFLICT message for repeated score s…

### DIFF
--- a/src/main/java/ru/epa/epabackend/repository/EmployeeEvaluationRepository.java
+++ b/src/main/java/ru/epa/epabackend/repository/EmployeeEvaluationRepository.java
@@ -201,4 +201,6 @@ public interface EmployeeEvaluationRepository extends JpaRepositoryImplementatio
     Double getAverageRatingByEvaluatedIdAndCurrentMonth(Long employeeId, LocalDate rangeStart, LocalDate rangeEnd);
 
     Boolean existsByEvaluatedIdOrEvaluatorId(Long employeeId, Long sameEmployeeId);
+
+    boolean existsByCriteriaIdIn(List<Long> criteriaIds);
 }

--- a/src/main/java/ru/epa/epabackend/repository/EmployeeEvaluationRepository.java
+++ b/src/main/java/ru/epa/epabackend/repository/EmployeeEvaluationRepository.java
@@ -202,5 +202,7 @@ public interface EmployeeEvaluationRepository extends JpaRepositoryImplementatio
 
     Boolean existsByEvaluatedIdOrEvaluatorId(Long employeeId, Long sameEmployeeId);
 
-    boolean existsByCriteriaIdIn(List<Long> criteriaIds);
+    boolean existsByEvaluatorIdAndCriteriaIdInAndQuestionnaireIdAndEvaluatedId(Long evaluatorId,
+                                                                               List<Long> criteriaIds,
+                                                                               Long questionnaireId, Long evaluatedId);
 }

--- a/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
+++ b/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
@@ -56,7 +56,8 @@ public class EmployeeEvaluationServiceImpl implements EmployeeEvaluationService 
         checkQuestionnaireForEvaluator(questionnaire, evaluator);
         List<Long> criteriaIds = evaluationRequestDtoList.stream()
                 .map(RequestEmployeeEvaluationDto::getCriteriaId).collect(Collectors.toList());
-        if (employeeEvaluationRepository.existsByCriteriaIdIn(criteriaIds)) {
+        if (employeeEvaluationRepository.existsByEvaluatorIdAndCriteriaIdInAndQuestionnaireIdAndEvaluatedId(evaluator.getId(),
+                criteriaIds, questionnaireId, evaluatedId)) {
             throw new ConflictException(String.format("Существует оценка по одному или нескольким критериям анкеты " +
                     "для оцениваемого пользователя %s", evaluated.getFullName()));
         }

--- a/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
+++ b/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
@@ -56,7 +56,7 @@ public class EmployeeEvaluationServiceImpl implements EmployeeEvaluationService 
         checkQuestionnaireForEvaluator(questionnaire, evaluator);
         List<Long> criteriaIds = evaluationRequestDtoList.stream()
                 .map(RequestEmployeeEvaluationDto::getCriteriaId).collect(Collectors.toList());
-        if(employeeEvaluationRepository.existsByCriteriaIdIn(criteriaIds)) {
+        if (employeeEvaluationRepository.existsByCriteriaIdIn(criteriaIds)) {
             throw new ConflictException(String.format("Существует оценка по одному или нескольким критериям анкеты " +
                     "для оцениваемого пользователя %s", evaluated.getFullName()));
         }

--- a/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
+++ b/src/main/java/ru/epa/epabackend/service/impl/EmployeeEvaluationServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.epa.epabackend.dto.evaluation.*;
 import ru.epa.epabackend.exception.exceptions.BadRequestException;
+import ru.epa.epabackend.exception.exceptions.ConflictException;
 import ru.epa.epabackend.mapper.EmployeeEvaluationMapper;
 import ru.epa.epabackend.model.*;
 import ru.epa.epabackend.repository.EmployeeEvaluationRepository;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static ru.epa.epabackend.util.Constants.THIRTY_DAYS;
 
@@ -52,6 +54,12 @@ public class EmployeeEvaluationServiceImpl implements EmployeeEvaluationService 
         Questionnaire questionnaire = questionnaireService.findById(questionnaireId);
         employeeService.checkEvaluatorForEmployee(evaluator, evaluated);
         checkQuestionnaireForEvaluator(questionnaire, evaluator);
+        List<Long> criteriaIds = evaluationRequestDtoList.stream()
+                .map(RequestEmployeeEvaluationDto::getCriteriaId).collect(Collectors.toList());
+        if(employeeEvaluationRepository.existsByCriteriaIdIn(criteriaIds)) {
+            throw new ConflictException(String.format("Существует оценка по одному или нескольким критериям анкеты " +
+                    "для оцениваемого пользователя %s", evaluated.getFullName()));
+        }
         List<EmployeeEvaluation> employeeEvaluations = new ArrayList<>(evaluationRequestDtoList.size());
 
         for (RequestEmployeeEvaluationDto evaluationRequestDto : evaluationRequestDtoList) {


### PR DESCRIPTION
 Стало намного короче сообщение 409 CONFLICT о нарушении уникальности ключа (повторной оценке одного или нескольких критериев анкеты)