### PR TITLE
fix(questionnaire): last questionnaire will find by date and id. Befo…

### DIFF
--- a/src/main/java/ru/epa/epabackend/repository/QuestionnaireRepository.java
+++ b/src/main/java/ru/epa/epabackend/repository/QuestionnaireRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface QuestionnaireRepository extends JpaRepository<Questionnaire, Long> {
     List<Questionnaire> findAllByAuthorIdAndStatus(Long authorId, QuestionnaireStatus shared);
 
-    Optional<Questionnaire> findFirstByAuthorEmailOrderByIdDesc(String email);
+    Optional<Questionnaire> findFirstByAuthorEmailOrderByCreatedDescIdDesc(String email);
 
     Optional<Questionnaire> findFirstByAuthorEmailAndStatusOrderByIdDesc(String authorEmail, QuestionnaireStatus status);
 }

--- a/src/main/java/ru/epa/epabackend/service/impl/QuestionnaireServiceImpl.java
+++ b/src/main/java/ru/epa/epabackend/service/impl/QuestionnaireServiceImpl.java
@@ -42,7 +42,7 @@ public class QuestionnaireServiceImpl implements QuestionnaireService {
     @Override
     public Questionnaire findLastByAuthorEmail(String email) {
         log.info("Получение самой последней анкеты админа по email");
-        Optional<Questionnaire> lastQuestionnaire = questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email);
+        Optional<Questionnaire> lastQuestionnaire = questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email);
         if (lastQuestionnaire.isPresent()) {
             Questionnaire questionnaire = lastQuestionnaire.get();
             if (QuestionnaireStatus.CREATED.equals(questionnaire.getStatus())) {
@@ -77,7 +77,7 @@ public class QuestionnaireServiceImpl implements QuestionnaireService {
     public Questionnaire updateLast(RequestQuestionnaireDto requestQuestionnaireDto, String email) {
         log.info("Обновление анкеты");
 
-        Optional<Questionnaire> lastQuestionnaire = questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email);
+        Optional<Questionnaire> lastQuestionnaire = questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email);
         if (lastQuestionnaire.isEmpty()) {
             throw new BadRequestException("Необходимо создать заранее анкету для возможности редактирования");
         } else if (QuestionnaireStatus.SHARED.equals(lastQuestionnaire.get().getStatus())) {
@@ -111,7 +111,7 @@ public class QuestionnaireServiceImpl implements QuestionnaireService {
     @Override
     public Questionnaire sendQuestionnaireToEmployees(String email) {
         log.info("Отправление анкеты сотрудникам");
-        Optional<Questionnaire> lastQuestionnaire = questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email);
+        Optional<Questionnaire> lastQuestionnaire = questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email);
         if (lastQuestionnaire.isPresent()) {
             Questionnaire questionnaire = lastQuestionnaire.get();
             if (QuestionnaireStatus.CREATED.equals(questionnaire.getStatus())) {

--- a/src/test/java/ru/epa/epabackend/questionnaire/QuestionnaireUnitTests.java
+++ b/src/test/java/ru/epa/epabackend/questionnaire/QuestionnaireUnitTests.java
@@ -92,7 +92,7 @@ public class QuestionnaireUnitTests {
     @DisplayName("Получение последней анкеты админа по email" +
             " Если есть анкета со статусом CREATED, то возвращаем её")
     void shouldFindLastByAuthorEmailWhenQuestionnaireHaveStatusCreated() {
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         questionnaire1 = lastQuestionnaire.get();
         Questionnaire questionnaireResult = questionnaireService.findLastByAuthorEmail(email1);
         int expectedId = 1;
@@ -104,7 +104,7 @@ public class QuestionnaireUnitTests {
     @DisplayName("Получение последней анкеты админа по email" +
             " У прошлой анкеты был статус SHARED, поэтому создаётся новая анкета со статусом CREATED")
     void shouldFindLastByAuthorEmailWhenQuestionnaireHaveStatusSHARED() {
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         questionnaire2 = lastQuestionnaire.get();
         questionnaire2.setStatus(QuestionnaireStatus.SHARED);
         when(employeeService.findByEmail(email1)).thenReturn(admin);
@@ -121,7 +121,7 @@ public class QuestionnaireUnitTests {
             " У админа не было анкет, поэтому создаётся новая анкета со статусом CREATED и дефолтными критериями")
     void shouldFindLastByAuthorEmailWhenAdminDontHaveQuestionnaire() {
         lastQuestionnaire = Optional.empty();
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email2)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email2)).thenReturn(lastQuestionnaire);
         when(employeeService.findByEmail(email2)).thenReturn(author);
         when(questionnaireService.saveWithParameters(QuestionnaireStatus.CREATED, admin, criterias))
                 .thenReturn(questionnaire1);
@@ -154,7 +154,7 @@ public class QuestionnaireUnitTests {
     void shouldUpdateLastWhenCallRepository() {
         uniqueCriterias = new HashSet<>();
         uniqueCriterias.add("criteriaDto");
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         when(criteriaService.findExistentAndSaveNonExistentCriterias(uniqueCriterias)).thenReturn(criterias);
         when(questionnaireRepository.save(questionnaire1)).thenReturn(questionnaire1);
         Questionnaire questionnaireResult = questionnaireService.updateLast(requestQuestionnaireDto, email1);
@@ -168,7 +168,7 @@ public class QuestionnaireUnitTests {
             " lastQuestionnaire.isEmpty")
     void shouldUpdateLastWhenLastQuestionnaireIsEmpty() {
         lastQuestionnaire = Optional.empty();
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         assertThrows(BadRequestException.class, () -> questionnaireService.updateLast(requestQuestionnaireDto, email1));
     }
 
@@ -178,7 +178,7 @@ public class QuestionnaireUnitTests {
     void shouldUpdateLastWhenLastQuestionnaireStatusIsShared() {
         questionnaire1.setStatus(QuestionnaireStatus.SHARED);
         lastQuestionnaire = Optional.of(questionnaire1);
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         assertThrows(BadRequestException.class, () -> questionnaireService.updateLast(requestQuestionnaireDto, email1));
     }
 
@@ -202,7 +202,7 @@ public class QuestionnaireUnitTests {
     @Test
     @DisplayName("Отправление анкеты сотрудникам - изменение статуса последней анкеты с CREATED на SHARED")
     void shouldSendQuestionnaireToEmployeesWhenCallRepositoryQuestionnaireStatusToShared() {
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         questionnaire1.setStatus(QuestionnaireStatus.SHARED);
         when(questionnaireService.sendQuestionnaireToEmployees(email1)).thenReturn(questionnaire1);
         Questionnaire questionnaireResult = questionnaireService.sendQuestionnaireToEmployees(email1);
@@ -216,7 +216,7 @@ public class QuestionnaireUnitTests {
     @DisplayName("Последняя анкета имела статус SHARED, поэтому создаётся дубликат анкеты с новым id и датой " +
             "и статусом SHARED")
     void shouldSendQuestionnaireToEmployeesWhenQuestionnaireHaveStatusShared() {
-        when(questionnaireRepository.findFirstByAuthorEmailOrderByIdDesc(email1)).thenReturn(lastQuestionnaire);
+        when(questionnaireRepository.findFirstByAuthorEmailOrderByCreatedDescIdDesc(email1)).thenReturn(lastQuestionnaire);
         when(employeeService.findByEmail(email1)).thenReturn(admin);
         questionnaire1.setStatus(QuestionnaireStatus.SHARED);
         when(questionnaireService


### PR DESCRIPTION
Для нахождения последней анкеты и распространения её использовался поиск по последнему id анкеты. Но в тестовых анкетах id был очень большой и возникал баг при создании новой анкеты и при проведении анкетирования. Для того, чтобы поиск был более корректным, теперь ищем по дате (самой последней), затем по id (самому последнему в эту дату)